### PR TITLE
Updating db access password for bitnami stateful chart upgrade

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,8 @@ spring:
 
   datasource:
     url: jdbc:mysql:thin://operations-mysql:3306/messagegateway
-    username: root
-    password: ethieTieCh8ahv
+    username: mifos
+    password: password
     driver-class-name: org.drizzle.jdbc.DrizzleDriver
 
 # Status Callback configuration for Twilio. Port will be taken from server configuration


### PR DESCRIPTION
Updating username and password as a fix for message gateway not coming up in lens.

Reason: Could not connect: Access denied for user 'root'@'10.244.2.112' (using password: YES)


Related to bitnami chart update PR:
https://github.com/fynarfin/ph-ee-env-template/pull/30/files
https://github.com/fynarfin/ph-ee-env-labs/pull/17/files


@SubhamPramanik @avikganguly01 