### PR TITLE
Updating db access and adding root password

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,8 @@ spring:
 
   datasource:
     url: jdbc:mysql:thin://operations-mysql:3306/messagegateway
-    username: mifos
-    password: password
+    username: root
+    password: 4ET6ywqlGt
     driver-class-name: org.drizzle.jdbc.DrizzleDriver
 
 # Status Callback configuration for Twilio. Port will be taken from server configuration


### PR DESCRIPTION
Since message gateway requires root access and with new upgrade root password has changed. Therefore providing message gateway root access for database.


@avikganguly01 @SubhamPramanik