### PR TITLE
Updating default value for submitted and delivered on date

### DIFF
--- a/src/main/resources/db/migration/V1__Initial_Setup.sql
+++ b/src/main/resources/db/migration/V1__Initial_Setup.sql
@@ -46,8 +46,8 @@ CREATE TABLE m_outbound_messages (
   source_address	      VARCHAR(100)                                    NULL DEFAULT NULL,
   sms_bridge_id           BIGINT(20)                                      NOT NULL,
   mobile_number           VARCHAR(255)                                    NOT NULL,
-  submitted_on_date       TIMESTAMP                                       NOT NULL DEFAULT NOW(),
-  delivered_on_date       TIMESTAMP                                       NOT NULL DEFAULT NOW(),
+  submitted_on_date       TIMESTAMP                                       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  delivered_on_date       TIMESTAMP                                       NOT NULL DEFAULT CURRENT_TIMESTAMP,
   delivery_status	      INT(3)										  NOT NULL,
   message		          VARCHAR(4096)                                   NOT NULL,
   CONSTRAINT `m_outbound_messages_1` FOREIGN KEY (`sms_bridge_id`) REFERENCES `m_sms_bridge` (`id`)


### PR DESCRIPTION
After mysql was upgraded (Commit no- https://github.com/fynarfin/ph-ee-env-template/commit/1204d74844de5237e252f27d2d2a273c0ae750c1), insert query was failing on this column:

delivered_on_date       TIMESTAMP                                       NOT NULL DEFAULT NOW(),

As a solution (to address the change in sql version to 8.8.23) the default NOW() method was changed to CURRENT_TIMESTAMP

Solution taken from : https://stackoverflow.com/questions/22665364/mysql-not-accepting-now-as-a-default-value-for-a-datetime-field


@avikganguly01 @SubhamPramanik please review.