### PR TITLE
Adding new migration script to alter default date value

### DIFF
--- a/src/main/resources/db/migration/V5__Updating_Default_DateValue.sql
+++ b/src/main/resources/db/migration/V5__Updating_Default_DateValue.sql
@@ -1,0 +1,21 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership. The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied. See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+ALTER TABLE m_outbound_messages MODIFY COLUMN submitted_on_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE m_outbound_messages MODIFY COLUMN delivered_on_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
After mysql was upgraded (Commit no- https://github.com/fynarfin/ph-ee-env-template/commit/1204d74844de5237e252f27d2d2a273c0ae750c1), insert query was failing on this column:

delivered_on_date TIMESTAMP NOT NULL DEFAULT NOW(),

As a solution (to address the change in sql version to 8.8.23) the default NOW() method was changed to CURRENT_TIMESTAMP

Solution taken from : https://stackoverflow.com/questions/22665364/mysql-not-accepting-now-as-a-default-value-for-a-datetime-field

@avikganguly01 @SubhamPramanik please review.