### PR TITLE
[PHEE-377] Upgrading telerevit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation('com.twilio.sdk:twilio:7.1.0')
     implementation('org.drizzle.jdbc:drizzle-jdbc:1.3')
     implementation('com.infobip:infobip-api-java-client:2.0.0')
-    implementation('com.telerivet:TelerivetAPIClient:1.5.0')
+    implementation('com.telerivet:TelerivetAPIClient:1.7.0')
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.6.0'
     implementation 'org.json:json:20210307'
     implementation 'org.springframework.kafka:spring-kafka:2.7.2'


### PR DESCRIPTION
- Upgrading telerevit version to 1.7.0
https://fynarfin.atlassian.net/browse/PHEE-377?
atlOrigin=eyJpIjoiM2RlYzIxODRkOGNkNGYzZTkwNDZjY2MyNTc4ODRmZWYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

The telerevit v1.5.0 is not available in maven repository : [https://mvnrepository.com/artifact/com.telerivet/TelerivetAPIClient](https://mvnrepository.com/artifact/com.telerivet/TelerivetAPIClient)

![image](https://github.com/openMF/message-gateway/assets/44061541/dc8f135b-e5b3-4218-b087-36c022e3252e)


@fynmanoj @somanath21 